### PR TITLE
Update Github when there are changes on CR and define a connection between CR and issue by serial number

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/rh-ee-slevi/github-operator-new
-  newTag: v1.7
+  newName: quay.io/rh-ee-slevi/github-operator
+  newTag: v3.4

--- a/internal/controller/githubissue_controller.go
+++ b/internal/controller/githubissue_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,7 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	trainingv1alpha1 "Shai1-Levi/githubissues-operator.git/api/v1alpha1"
+
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"bytes"
@@ -41,6 +44,13 @@ import (
 type GithubIssueReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+}
+
+// Define a struct to hold the relevant parts of the GitHub Search API response.
+// We only care about total_count for this example.
+type GitHubSearchResponse struct {
+	TotalCount int                      `json:"total_count"` // Maps the JSON key "total_count" to this field
+	Items      []map[string]interface{} `json:"items"`
 }
 
 // +kubebuilder:rbac:groups=training.redhat.com,resources=githubissues,verbs=get;list;watch;create;update;patch;delete
@@ -72,7 +82,7 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			// GitHubIssue CR was not found, and it could have been deleted after reconcile request.
 			// Return and don't requeue
 			logStr := fmt.Sprintf("GithubIssue CR was not found, CR Name %s CR Namespace %s", req.Name, req.Namespace)
-			log.Error(err, logStr)
+			log.Info(logStr)
 			return emptyResult, nil
 		}
 		log.Error(err, "Failed to get GithubIssue CR")
@@ -122,17 +132,23 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Fetch issues from GitHub
 	body, err := r.fetchGitHubIssues(accessToken)
 	if err != nil {
-		log.Error(nil, "Failed to fetch GitHub issues")
+		log.Info("Failed to fetch GitHub issues")
 		return emptyResult, nil
 	}
 
 	// Define a generic map for GitHubIssues
-	var gitHubIssues []map[string]interface{}
+	// var gitHubIssues []map[string]interface{}
+
+	fmt.Printf("HEREEEEEEEE")
+
+	// 1. Create an instance of our struct
+	var gitHubIssues GitHubSearchResponse
 
 	// Parse the JSON
 	err = json.Unmarshal(body, &gitHubIssues)
 	if err != nil {
-		log.Error(nil, "err\n")
+		fmt.Print(err)
+		log.Info("Failed to parase response to JSon")
 	}
 
 	// The object is being deleted
@@ -140,27 +156,10 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Delete CR only when a finalizer and DeletionTimestamp are set
 		// our finalizer is present, handle any external dependency
 
-		title := ghi.Spec.Title
-		description := ghi.Spec.Description
-
-		var i int
-		var url string
-		url = ""
-		// Print all keys and values dynamically
-		for i = 0; i < len(gitHubIssues); i++ {
-			item := gitHubIssues[i]
-			fmt.Printf("\nIssue %d:\n", i)
-			titleStr := fmt.Sprintf(item["title"].(string))
-			isOpen := fmt.Sprintf(item["state"].(string))
-			url = fmt.Sprintf(item["url"].(string))
-			if (strings.TrimRight(string(titleStr), "\n") == title) && isOpen == "open" {
-				if _, err := r.closeGithubIssue(title, description, url, accessToken); err != nil {
-					// if fail to delete the external dependency here, return with error
-					// so that it can be retried.
-					return emptyResult, err
-				}
-				break
-			}
+		if _, err := r.sentCloseGithubIssue(ghi, gitHubIssues, accessToken); err != nil {
+			// if fail to delete the external dependency here, return with error
+			// so that it can be retried.
+			return emptyResult, err
 		}
 
 		log.Info("Trying RemoveFinalizer")
@@ -179,27 +178,249 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	title := ghi.Spec.Title
 	description := ghi.Spec.Description
 	repo := ghi.Spec.Repo
+	annotationKey := "github-issue.kubebuilder.io/issue-number"
 
-	var i int
-	fmt.Printf("number %d", len(gitHubIssues))
-	for i = 0; i < len(gitHubIssues); i++ {
-		item := gitHubIssues[i]
-		fmt.Printf("\nIssue %d:\n", i)
-		titleStr := fmt.Sprintf(item["title"].(string))
-		isOpen := fmt.Sprintf(item["state"].(string))
-		if (strings.TrimRight(string(titleStr), "\n") == title) && isOpen == "open" {
-			break
+	if r.hasSpecificAnnotation(ghi, annotationKey) {
+		fmt.Printf("CR has the annotation key %s \n", annotationKey)
+
+		// 3. (Optional) Get the value of the annotation
+		value, _ := r.getSpecificAnnotationValue(ghi, annotationKey)
+		fmt.Printf("Annotation value key %s value %s \n", annotationKey, value)
+
+		// Now you can act based on the presence or value of the annotation
+		if value != "" {
+			// Do something specific
+			log.Info("Annotation value is true, performing action...")
+			ghiBySerial, err := r.fetchGitHubIssuesbyIssueNumber(value, accessToken)
+			if err != nil {
+				fmt.Print(err)
+				log.Info("Failed to parase response to JSon")
+			}
+
+			// Declare a map to hold the unmarshaled JSON
+			var result map[string]interface{}
+
+			// Unmarshal the JSON data into the map
+			err = json.Unmarshal(ghiBySerial, &result)
+			if err != nil {
+				fmt.Printf("Error unmarshaling JSON: %v", err)
+			}
+			if result["title"] != title || result["body"] != description {
+				needUpdate := r.updateGitHubIssue(title, description, repo, value, accessToken)
+				if !needUpdate {
+					return emptyResult, nil
+				}
+			}
+
+			return emptyResult, nil
+
 		}
-	}
 
-	fmt.Printf("index: %d", i)
-	// validate if the requiered GitHub issue is not exists when GitHub issues are empty or not
-	if len(gitHubIssues) == 0 || i == len(gitHubIssues) {
-		r.createGithubIssue(title, description, repo, accessToken)
-		log.Info("Reconciling createGithubIssue")
+	} else { // No anttotaion filed, hence CR is on creation serp
+		log.Info("CR does not have the annotation", "key", annotationKey)
+		var i int
+		fmt.Printf("number %d", len(gitHubIssues.Items))
+		for i = 0; i < len(gitHubIssues.Items); i++ {
+			item := gitHubIssues.Items[i]
+			fmt.Printf("\nIssue %d:\n", i)
+			titleStr := fmt.Sprintf(item["title"].(string))
+			isOpen := fmt.Sprintf(item["state"].(string))
+			if (strings.TrimRight(string(titleStr), "\n") == title) && isOpen == "open" {
+				break
+			}
+		}
+
+		fmt.Printf("index: %d", i)
+		// validate if the requiered GitHub issue is not exists when GitHub issues are empty or not
+		if len(gitHubIssues.Items) == 0 || i == len(gitHubIssues.Items) {
+			annotationValue, err := r.createGithubIssue(title, description, repo, accessToken)
+			if annotationValue == "" {
+				fmt.Printf("annotation value is empty string something went wrong")
+				return emptyResult, err
+			}
+
+			if err := r.UpdateGithubIssueAnnotation(ctx, req, annotationKey, annotationValue); err != nil {
+				// Handle error, potentially requeue
+				return emptyResult, err
+			}
+			log.Info("Reconciling createGithubIssue")
+		}
+
+		return emptyResult, nil
 	}
 
 	return emptyResult, nil
+
+}
+
+func (r *GithubIssueReconciler) updateGitHubIssue(title string, description string, repo string, issueNumber string, accessToken string) bool {
+
+	// // Declare a map to hold the unmarshaled JSON
+	// var result map[string]interface{}
+
+	// // Unmarshal the JSON data into the map
+	// err := json.Unmarshal(ghiBySerial, &result)
+	// if err != nil {
+	// 	fmt.Printf("Error unmarshaling JSON: %v", err)
+	// }
+
+	// fmt.Print("result")
+	// fmt.Print(result)
+	fmt.Print(repo)
+	// title := result["title"].(string)
+	// description := result["body"].(string)
+	// url := result["html_url"].(string)
+	url := fmt.Sprintf("https://api.github.com/repos/Shai1-Levi/githubissues-operator/issues/%s", issueNumber)
+
+	fmt.Printf("titleeeee SHai\n")
+	fmt.Print(title)
+
+	fmt.Printf("descriptionnnnnn SHAI\n")
+	fmt.Print(description)
+
+	fmt.Printf("\n urllll SHAI\n")
+	fmt.Print(url)
+
+	ans, e := r.updateGitHubIssuefileds(title, description, url, accessToken)
+	if e != nil {
+		fmt.Print(e)
+		fmt.Printf("Failed to parase response to JSon")
+	}
+
+	return ans
+	// return true
+
+}
+
+func (r *GithubIssueReconciler) hasSpecificAnnotation(obj metav1.Object, annotationKey string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false // No annotations at all
+	}
+	_, exists := annotations[annotationKey]
+	return exists
+}
+
+func (r *GithubIssueReconciler) getSpecificAnnotationValue(obj metav1.Object, annotationKey string) (string, bool) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return "", false // No annotations at all
+	}
+	value, exists := annotations[annotationKey]
+	return value, exists
+}
+
+// Function to add or update an annotation on a GithubIssue CR
+func (r *GithubIssueReconciler) UpdateGithubIssueAnnotation(
+	ctx context.Context,
+	req ctrl.Request,
+	annotationKey string,
+	annotationValue string,
+) error {
+	logger := log.FromContext(ctx).WithValues("githubissue", req.NamespacedName)
+
+	// 1. Get the GithubIssue CR
+	githubIssue := &trainingv1alpha1.GithubIssue{}
+	if err := r.Get(ctx, req.NamespacedName, githubIssue); err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Info("GithubIssue not found, cannot update annotation.")
+			return nil // Or return error if this is unexpected
+		}
+		logger.Error(err, "Failed to get GithubIssue to update annotation")
+		return err
+	}
+
+	// 2. Modify Annotations
+	// Initialize the Annotations map if it's nil
+	if githubIssue.ObjectMeta.Annotations == nil {
+		githubIssue.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	// Check if the annotation value actually needs updating
+	currentValue, exists := githubIssue.ObjectMeta.Annotations[annotationKey]
+	if exists && currentValue == annotationValue {
+		logger.Info("Annotation already has the desired value, no update needed.", "key", annotationKey, "value", annotationValue)
+		return nil
+	}
+
+	// Add or update the annotation
+	githubIssue.ObjectMeta.Annotations[annotationKey] = annotationValue
+	logger.Info("Updating annotation", "key", annotationKey, "value", annotationValue)
+
+	// 3. Update the GithubIssue CR
+	if err := r.Client.Update(ctx, githubIssue); err != nil {
+		logger.Error(err, "Failed to update GithubIssue with new annotation")
+		return err
+	}
+
+	logger.Info("Successfully updated GithubIssue annotation", "key", annotationKey, "value", annotationValue)
+	return nil
+}
+
+func (r *GithubIssueReconciler) sentCloseGithubIssue(ghi *trainingv1alpha1.GithubIssue, gitHubIssues GitHubSearchResponse, accessToken string) (ctrl.Result, error) {
+
+	title := ghi.Spec.Title
+	description := ghi.Spec.Description
+
+	var i int
+	var url string
+	url = ""
+	// Print all keys and values dynamically
+	for i = 0; i < len(gitHubIssues.Items); i++ {
+		item := gitHubIssues.Items[i]
+		fmt.Printf("\nIssue %d:\n", i)
+		titleStr := fmt.Sprintf(item["title"].(string))
+		isOpen := fmt.Sprintf(item["state"].(string))
+		url = fmt.Sprintf(item["url"].(string))
+		if (strings.TrimRight(string(titleStr), "\n") == title) && isOpen == "open" {
+			if _, err := r.closeGithubIssue(title, description, url, accessToken); err != nil {
+				// if fail to delete the external dependency here, return with error
+				// so that it can be retried.
+				return ctrl.Result{}, err
+			}
+			break
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *GithubIssueReconciler) updateGitHubIssuefileds(title string, description string, repo string, accessToken string) (bool, error) {
+	// Trim spaces and newlines from the token
+	tokenStr := strings.TrimSpace(accessToken)
+
+	// JSON payload for the issue
+	jsonStr := fmt.Sprintf("{\"title\":\"%s\", \"body\":\"%s\", \"state\":\"open\"}", title, description)
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("PATCH", repo, bytes.NewBuffer([]byte(jsonStr)))
+	if err != nil {
+		return false, fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Add("Authorization", "token "+tokenStr)
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+
+	// The GitHub REST API is versioned.
+	// The API version name is based on the date when the API version was released.
+	// For example, the API version 2022-11-28 was released on Mon, 28 Nov 2022.
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+
+	// Create HTTP client and send request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("error reading token: \n")
+		return false, fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusCreated {
+		return false, fmt.Errorf("GitHub API returned status: %d", resp.StatusCode)
+	}
+
+	return true, nil
 }
 
 func (r *GithubIssueReconciler) closeGithubIssue(title string, description string, url string, accessToken string) (ctrl.Result, error) {
@@ -242,19 +463,18 @@ func (r *GithubIssueReconciler) closeGithubIssue(title string, description strin
 	return ctrl.Result{}, nil
 }
 
-func (r *GithubIssueReconciler) createGithubIssue(title string, description string, repo string, accessToken string) (ctrl.Result, error) {
+func (r *GithubIssueReconciler) createGithubIssue(title string, description string, repo string, accessToken string) (string, error) {
 
 	// Trim spaces and newlines from the token
 	tokenStr := strings.TrimSpace(accessToken)
 
 	// JSON payload for the issue
 	jsonStr := fmt.Sprintf("{\"title\":\"%s\", \"body\":\"%s\", \"state\":\"open\"}", title, description)
-	// url := "https://api.github.com/repos/Shai1-Levi/githubissues-operator/issues"
 
 	// Create a new HTTP request
 	req, err := http.NewRequest("POST", repo, bytes.NewBuffer([]byte(jsonStr)))
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("error creating request: %w", err)
+		return "", fmt.Errorf("error creating request: %w", err)
 	}
 
 	// Set headers
@@ -271,16 +491,70 @@ func (r *GithubIssueReconciler) createGithubIssue(title string, description stri
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Printf("error reading token: \n")
-		return ctrl.Result{}, fmt.Errorf("error sending request: %w", err)
+		return "", fmt.Errorf("error sending request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// Check response status
 	if resp.StatusCode != http.StatusCreated {
-		return ctrl.Result{}, fmt.Errorf("GitHub API returned status: %d", resp.StatusCode)
+		return "", fmt.Errorf("GitHub API returned status: %d", resp.StatusCode)
 	}
 
-	return ctrl.Result{}, nil
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response: %w", err)
+	}
+
+	// Declare a map to hold the unmarshaled JSON
+	var result map[string]interface{}
+
+	// Unmarshal the JSON data into the map
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		fmt.Printf("Error unmarshaling JSON: %v", err)
+	}
+
+	// Access the "url" field
+	// You need to perform a type assertion to get the string value
+	urlValue, ok := result["url"]
+	if !ok {
+		fmt.Printf("'url' field not found in JSON response")
+	}
+
+	urlString, ok := urlValue.(string)
+	if !ok {
+		fmt.Printf("'url' field is not a string, actual type: %T", urlValue)
+	}
+
+	_, numberStr, err := r.extractIssueNumberFromString(urlString)
+	if err != nil {
+		fmt.Printf("Error unmarshaling JSON: %v\n", err)
+		return "", err
+	}
+
+	return numberStr, nil
+}
+
+func (r *GithubIssueReconciler) extractIssueNumberFromString(s string) (int, string, error) {
+	lastSlashIndex := strings.LastIndex(s, "/")
+	if lastSlashIndex == -1 {
+		return 0, "", fmt.Errorf("no '/' found in string")
+	}
+
+	// Extract the part after the last slash
+	potentialNumberStr := s[lastSlashIndex+1:]
+	if potentialNumberStr == "" {
+		return 0, "", fmt.Errorf("string ends with '/', no number found after it")
+	}
+
+	// Attempt to convert the extracted part to an integer
+	number, err := strconv.Atoi(potentialNumberStr)
+	if err != nil {
+		return 0, potentialNumberStr, fmt.Errorf("could not convert '%s' to an integer: %w", potentialNumberStr, err)
+	}
+
+	return number, potentialNumberStr, nil
 }
 
 // fetchGitHubIssues reads the token, sends the request, and returns the response body
@@ -299,6 +573,7 @@ func (r *GithubIssueReconciler) fetchGitHubIssues(accessToken string) ([]byte, e
 	// Set headers
 	req.Header.Add("Authorization", "token "+tokenStr)
 	req.Header.Add("Accept", "application/vnd.github.v3+json")
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
 
 	// Send request
 	client := &http.Client{}
@@ -313,6 +588,58 @@ func (r *GithubIssueReconciler) fetchGitHubIssues(accessToken string) ([]byte, e
 	if err != nil {
 		return nil, fmt.Errorf("error reading response: %w", err)
 	}
+
+	return body, nil
+}
+
+// fetchGitHubIssues reads the token, sends the request, and returns the response body
+func (r *GithubIssueReconciler) fetchGitHubIssuesbyIssueNumber(issueNumber string, accessToken string) ([]byte, error) {
+
+	// Trim spaces and newlines from the token
+	tokenStr := strings.TrimSpace(accessToken)
+	url := fmt.Sprintf("https://api.github.com/repos/Shai1-Levi/githubissues-operator/issues/%s", issueNumber)
+
+	fmt.Printf("\nURL: ")
+	fmt.Print(url)
+	fmt.Printf("\n")
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Add("Authorization", "token "+tokenStr)
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+
+	// Send request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %w", err)
+	}
+
+	// Declare a map to hold the unmarshaled JSON
+	var result map[string]interface{}
+
+	// Unmarshal the JSON data into the map
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		fmt.Printf("Error unmarshaling JSON: %v", err)
+	}
+
+	fmt.Print("\n result")
+	fmt.Print(result)
+	fmt.Printf("\n")
 
 	return body, nil
 }


### PR DESCRIPTION

1. add option to track github issue by number, add the number as annotation
2. update issue number from github after creating new github issue
3. add infrastructure to handle the case when issues on github created by user and not created as a CR by the user. in this case I will open CR automatically as part of the code
4. Fetch only open issues instead of all issues